### PR TITLE
suppress deprecated warning

### DIFF
--- a/furoshiki2.rb
+++ b/furoshiki2.rb
@@ -4,7 +4,7 @@ class Furoshiki2 < Formula
   homepage "https://github.com/motemen/furoshiki2"
   head "https://github.com/motemen/furoshiki2.git"
 
-  depends_on :python3
+  depends_on "python3"
 
   resource "PyYAML" do
     url "https://files.pythonhosted.org/packages/4a/85/db5a2df477072b2902b0eb892feb37d88ac635d36245a72a6a69b23b383a/PyYAML-3.12.tar.gz"


### PR DESCRIPTION
```
13:28 > brew outdated
Warning: Calling 'depends_on :python3' is deprecated!
Use 'depends_on "python3"' instead.
/usr/local/Homebrew/Library/Taps/motemen/homebrew-furoshiki2/furoshiki2.rb:7:in `<class:Furoshiki2>'
Please report this to the motemen/furoshiki2 tap!
```