### PR TITLE
Update PyYAML to 3.13 to fix installation error on Python3.7

### DIFF
--- a/furoshiki2.rb
+++ b/furoshiki2.rb
@@ -7,8 +7,8 @@ class Furoshiki2 < Formula
   depends_on "python3"
 
   resource "PyYAML" do
-    url "https://files.pythonhosted.org/packages/4a/85/db5a2df477072b2902b0eb892feb37d88ac635d36245a72a6a69b23b383a/PyYAML-3.12.tar.gz"
-    sha256 "592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab"
+    url "https://files.pythonhosted.org/packages/9e/a3/1d13970c3f36777c583f136c136f804d70f500168edc1edea6daa7200769/PyYAML-3.13.tar.gz"
+    sha256 "3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf"
   end
 
   def install


### PR DESCRIPTION
See https://github.com/yaml/pyyaml/issues/152