### PR TITLE
Update PyYAML to 5.4.1 to fix installation error on Python3.9

### DIFF
--- a/furoshiki2.rb
+++ b/furoshiki2.rb
@@ -7,8 +7,8 @@ class Furoshiki2 < Formula
   depends_on "python3"
 
   resource "PyYAML" do
-    url "https://files.pythonhosted.org/packages/9e/a3/1d13970c3f36777c583f136c136f804d70f500168edc1edea6daa7200769/PyYAML-3.13.tar.gz"
-    sha256 "3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf"
+    url "https://files.pythonhosted.org/packages/a0/a4/d63f2d7597e1a4b55aa3b4d6c5b029991d3b824b5bd331af8d4ab1ed687d/PyYAML-5.4.1.tar.gz"
+    sha256 "607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"
   end
 
   def install


### PR DESCRIPTION
furoshiki2 just using safe_load, so it won't be a problem to update PyYAML. It worked in my local environment with `python@3.9: stable 3.9.1 (bottled)`

- https://github.com/yaml/pyyaml/releases?after=5.1b1
    - The next version after 3.13 is 5.1 because 4.1 is retracted.
- https://github.com/yaml/pyyaml/issues/265
- https://github.com/yaml/pyyaml/issues/420#issuecomment-696752389
- url and sha256
    - https://pypi.org/project/PyYAML/5.4.1/#files