### PR TITLE
Update PyYAML to 6.0.1 to fix installation on Python 3.10 and after

### DIFF
--- a/furoshiki2.rb
+++ b/furoshiki2.rb
@@ -7,8 +7,8 @@ class Furoshiki2 < Formula
   depends_on "python3"
 
   resource "PyYAML" do
-    url "https://files.pythonhosted.org/packages/a0/a4/d63f2d7597e1a4b55aa3b4d6c5b029991d3b824b5bd331af8d4ab1ed687d/PyYAML-5.4.1.tar.gz"
-    sha256 "607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"
+    url "https://files.pythonhosted.org/packages/cd/e5/af35f7ea75cf72f2cd079c95ee16797de7cd71f29ea7c68ae5ce7be1eda0/PyYAML-6.0.1.tar.gz"
+    sha256 "bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"
   end
 
   def install


### PR DESCRIPTION
### got

`brew install --HEAD motemen/furoshiki2/furoshiki2` failed on Python 3.12

<details><summary>log</summary>
<p>

```sh
$ brew install --HEAD motemen/furoshiki2/furoshiki2
==> Auto-updating Homebrew...
Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with
HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> New Formulae
gcc@13

You have 1 outdated formula installed.

==> Fetching motemen/furoshiki2/furoshiki2
==> Downloading https://files.pythonhosted.org/packages/a0/a4/d63f2d7597e1a4b55aa3b4d6c5b029991d3b824b5bd331af8d4ab1ed687d/PyYAML-5.4.1.tar.gz
Already downloaded: /Users/hogashi/Library/Caches/Homebrew/downloads/22ccede1c6673431cec4016da36c594bf2b6a202919d431a5e81b63ec5bb75a3--PyYAML-5.4.1.tar.gz
==> Cloning https://github.com/motemen/furoshiki2.git
Updating /Users/hogashi/Library/Caches/Homebrew/furoshiki2--git
==> Checking out branch master
Already on 'master'
Your branch is up to date with 'origin/master'.
HEAD is now at 9c97d4c friendly readme
==> Installing furoshiki2 from motemen/furoshiki2
==> python3 -m venv --system-site-packages --without-pip /opt/homebrew/Cellar/furoshiki2/HEAD-9c97d4c/libexec
==> python3 -m pip --python=/opt/homebrew/Cellar/furoshiki2/HEAD-9c97d4c/libexec/bin/python install /private/tmp/furoshiki2--PyYAML-20240508-6650-c3okq
Last 15 lines from /Users/hogashi/Library/Logs/Homebrew/furoshiki2/02.python3:
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> See above for output.

  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: /opt/homebrew/Cellar/furoshiki2/HEAD-9c97d4c/libexec/bin/python /opt/homebrew/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py get_requires_for_build_wheel /private/tmp/tmpikvexyzm
  cwd: /private/tmp/furoshiki2--PyYAML-20240508-6650-c3okq/PyYAML-5.4.1
  Getting requirements to build wheel: finished with status 'error'
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.

If reporting this issue please do so at (not Homebrew/brew or Homebrew/homebrew-core):
  https://github.com/motemen/homebrew-furoshiki2/issues

furoshiki2's formula was built from an unstable upstream --HEAD.
This build failure is expected behaviour.
Do not create issues about this on Homebrew's GitHub repositories.
Any opened issues will be immediately closed without response.
Do not ask for help from Homebrew or its maintainers on social media.
You may ask for help in Homebrew's discussions but are unlikely to receive a response.
Try to figure out the problem yourself and submit a fix as a pull request.
We will review it but may or may not accept it.
```

</p>
</details> 

### expected

`brew install --HEAD motemen/furoshiki2/furoshiki2` succeeds and `furo2` command is in PATH even on Python 3.12

### what I did

Updated PyYAML version from 5.4.1 to 6.0.1 because it fails to be installed on Python 3.10 and after. Cython version is pinned to <3 at PyYAML 6.0.1.

Tarball URL and shasum are from https://pypi.org/project/PyYAML/6.0.1/

ref:

- [📝2023-07-20 PyYAMLの5.4.1がChefBuildErrorでインストールできない - Minerva](https://minerva.mamansoft.net/Notes/%F0%9F%93%9D2023-07-20+PyYAML%E3%81%AE5.4.1%E3%81%8CChefBuildError%E3%81%A7%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E3%81%A7%E3%81%8D%E3%81%AA%E3%81%84)
- https://github.com/yaml/pyyaml/issues/724
  - https://github.com/yaml/pyyaml/issues/724#issuecomment-1638717190
  - https://github.com/yaml/pyyaml/issues/724#issuecomment-1639579725
